### PR TITLE
Fix scroll areas overlap

### DIFF
--- a/Sources/ShamsiDatePicker/Extensions/PickerExtension.swift
+++ b/Sources/ShamsiDatePicker/Extensions/PickerExtension.swift
@@ -1,0 +1,18 @@
+//
+//  PickerExtension.swift
+//  
+//
+//  Created by Farzin Firoozi on 8/4/22.
+//
+
+import Foundation
+import SwiftUI
+
+extension UIPickerView {
+    override open var intrinsicContentSize: CGSize {
+        return CGSize(
+            width: UIView.noIntrinsicMetric,
+            height: super.intrinsicContentSize.height
+        )
+    }
+}


### PR DESCRIPTION
Scrollable areas are overlapped in iOS 15 and above.
This fixes the issue.